### PR TITLE
run always use DefaultOption

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,10 @@ module.exports = (function () {
             });
         }
     }
-
+    var options = merge({}, defaultOptions);
     return {
-        run: function (options) {
-            options = merge(defaultOptions, options || {});
+        run: function (newOptions) {
+            options = merge(options, newOptions || {});
 
             if (service) {    //stop
                 service.kill('SIGKILL');


### PR DESCRIPTION
when run is called without param, the `defaultOptions` is always used.

this PR change it, 
when run is called 1st time:
    we use the option which is merged from `default` and `options from param`.
    And save it.
when run is called again,
    The `option uesd last time` is merged with `the new param options`( if it is given ).
    Then we use this new options.

in this way, the server.run can be called once and run again and again without options any more.
