### PR TITLE
Fixed passing of NODE_ENV setting to Express

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,8 @@ module.exports = (function () {
                 livereload.start(options.port);
             }
 
-            service = child_process.spawn('node', [options.file], {
-                NODE_ENV: options.env
-            });
+            process.env.NODE_ENV = options.env;
+            service = child_process.spawn('node', [options.file]);
             service.stdout.setEncoding('utf8');
             service.stdout.on('data', function (data) {
                 console.log(data);


### PR DESCRIPTION
The line:

```
       service = child_process.spawn('node', [options.file], {
            NODE_ENV: options.env
        });
```

did not actually set NODE_ENV to options.env.

This does work:

```
        process.env.NODE_ENV = options.env;
        service = child_process.spawn('node', [options.file]);
```

Third parameter of child_process.spawn is not required because it defaults to process.env.
