### PR TITLE
Fix parent process environment propagation to child

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,27 +31,25 @@ module.exports = (function () {
         run: function (newOptions) {
             var options = merge(defaultOptions, newOptions || {});
 
-            if (service) {    //stop
+            if (service) { // Stop
                 service.kill('SIGKILL');
                 service = undefined;
             } else {
                 livereload.start(options.port);
             }
 
-            process.env.NODE_ENV = options.env;
-
-            if (options.args === undefined) {
-                service = child_process.spawn('node', [options.file], {
-                    NODE_ENV: options.env
-                });
-            } else {
-                var args = options.args;
-                args.push(options.file);
-                service = child_process.spawn('node', args, {
-                    NODE_ENV: options.env
-                });                
+            if (options.env) {
+                process.env.NODE_ENV = options.env;
             }
 
+            var args = null;
+            if (!options.args) {
+                args = [options.file];
+            } else {
+                args = options.args;
+                args.push(options.file);
+            }
+            service = child_process.spawn('node', args);
             service.stdout.setEncoding('utf8');
             service.stderr.setEncoding('utf8');
             service.stdout.on('data', function (data) {
@@ -61,10 +59,10 @@ module.exports = (function () {
                 console.log(data.trim());
             });
             service.on('exit', function (code, sig) {
-                console.log('service process exit ... ', code, sig);
+                console.log('service process exit ...', code, sig);
             });
             process.on('exit', function (code, sig) {
-                console.log('main process exit ... ', code, sig);
+                console.log('main process exit ...', code, sig);
                 service.kill();
             });
 


### PR DESCRIPTION
Third argument of child_process.spawn was not correct according to the [docs](http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options). The PR fixes that allowing to pass parent process environment to the child.
