### PR TITLE
Fixed a bug that causes gulp-express to throw error when running server.run for second time

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = (function () {
             if (node) { // Stop
                 node.kill('SIGKILL');
                 node = undefined;
-                process.removeListener('exit', processExitListener);
+                process.removeListener('exit', listener.processExit);
             } else {
                 livereload.start(options.port);
             }


### PR DESCRIPTION
This line of code should be changed to `listener.processExit`, as `processExitListener` is not defined.

### What we would expect:
`gulp-express` will kill the current node process and remove the `exit` listener before starting a new node process as defined in the source (lines 62–66):
```javascript
// gulp-express/index.js:62

if (node) { // Stop
  node.kill('SIGKILL');
  node = undefined;
  process.removeListener('exit', processExitListener);
} ...
```

### What we get:
`ReferenceError: processExitListener is not defined` is thrown when running `server.run()` after already running `server.run()` in order to restart the server.

### Practical example
```javascript
gulp.task('server:start', function () {
  server.run();
  ...
  gulp.watch('./app/**', ['server:restart']);
});

gulp.task('server:restart', function () {
  server.run(); // This will throw the error.
});
```