### PR TITLE
Close tiny lr instead of kill the main process

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = (function () {
             debug(info('server process exited with [code => %s | sig => %s]'), code, sig);
             if(sig !== 'SIGKILL'){
                 //server stopped unexpectedly
-                process.exit(0);
+                if (lr) {
+                    lr.close();
+                }
             }
         },
 


### PR DESCRIPTION
Closing tiny lr instead of killing the main process for issue #34.

I think this is the best solution when the child process failed.
