### PR TITLE
Check the livereload argument type is number

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = (function () {
             }else if(livereload){
                 if(typeof livereload === 'object'){
                     config.livereload = livereload;
-                }else{
+                }else if (typeof livereload === 'number'){
                     config.livereload.port = livereload;
                 }
             }


### PR DESCRIPTION
Happy new year :bamboo:

When I run the following code, I got `config.livereload.port === true`.
I expect to be a  `config.livereload.port === 35729 (default value)`.

``` js
server.run(['app.js'], options, true);
```

or 

``` js
var is_development = env.NODE_ENV === "development";
server.run(['app.js'], options, is_development);
```
